### PR TITLE
Handle Multiple Terms and Conditions Documents and Improved Modal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,10 @@ Note that you can skip @login_required only if you are forcing auth on that view
 
 Requiring T&Cs for Anonymous Users is not supported.
 
+Many of the templates extend the 'base.html' template by default. The TERMS_BASE_TEMPLATE setting can be used to specify a different template to extend::
+
+    TERMS_BASE_TEMPLATE = 'page.html'
+
 Terms and Conditions Template Tag
 ---------------------------------
 

--- a/termsandconditions/forms.py
+++ b/termsandconditions/forms.py
@@ -6,16 +6,35 @@ from django import forms
 from termsandconditions.models import UserTermsAndConditions, TermsAndConditions
 
 
-class UserTermsAndConditionsModelForm(forms.ModelForm):
+class UserTermsAndConditionsModelForm(forms.Form):
     """Form used when accepting Terms and Conditions - returnTo is used to catch where to end up."""
-
     returnTo = forms.CharField(required=False, initial="/", widget=forms.HiddenInput())
+    terms = forms.ModelMultipleChoiceField(
+        TermsAndConditions.get_active_list(as_dict=False),
+        widget=forms.MultipleHiddenInput
+    )
 
-    class Meta(object):
-        """Configuration for this Modelform"""
-        model = UserTermsAndConditions
-        exclude = ('date_accepted', 'ip_address', 'user')
-        widgets = {'terms': forms.HiddenInput()}
+    def __init__(self, *args, **kwargs):
+        print(kwargs)
+        if 'instance' in kwargs:
+            instance = kwargs.pop('instance')
+            print(instance)
+
+        if 'initial' in kwargs:
+            initial = kwargs.get('initial')
+
+            if 'terms' in initial:
+                self.terms = forms.ModelMultipleChoiceField(
+                    initial.get('terms'),
+                    widget=forms.MultipleHiddenInput
+                )
+
+        if kwargs.get('terms'):
+            self.terms = forms.ModelMultipleChoiceField(
+                TermsAndConditions.get_active_list(as_dict=False),
+                widget=forms.MultipleHiddenInput
+            )
+        super(UserTermsAndConditionsModelForm, self).__init__(*args, **kwargs)
 
 
 class EmailTermsForm(forms.Form):

--- a/termsandconditions/forms.py
+++ b/termsandconditions/forms.py
@@ -3,7 +3,7 @@
 # pylint: disable=E1120,W0613
 
 from django import forms
-from termsandconditions.models import UserTermsAndConditions, TermsAndConditions
+from termsandconditions.models import TermsAndConditions
 
 
 class UserTermsAndConditionsModelForm(forms.Form):
@@ -11,14 +11,12 @@ class UserTermsAndConditionsModelForm(forms.Form):
     returnTo = forms.CharField(required=False, initial="/", widget=forms.HiddenInput())
     terms = forms.ModelMultipleChoiceField(
         TermsAndConditions.get_active_list(as_dict=False),
-        widget=forms.MultipleHiddenInput
+        widget=forms.MultipleHiddenInput,
     )
 
     def __init__(self, *args, **kwargs):
-        print(kwargs)
         if 'instance' in kwargs:
-            instance = kwargs.pop('instance')
-            print(instance)
+            kwargs.pop('instance')
 
         if 'initial' in kwargs:
             initial = kwargs.get('initial')
@@ -26,14 +24,8 @@ class UserTermsAndConditionsModelForm(forms.Form):
             if 'terms' in initial:
                 self.terms = forms.ModelMultipleChoiceField(
                     initial.get('terms'),
-                    widget=forms.MultipleHiddenInput
+                    widget=forms.MultipleHiddenInput,
                 )
-
-        if kwargs.get('terms'):
-            self.terms = forms.ModelMultipleChoiceField(
-                TermsAndConditions.get_active_list(as_dict=False),
-                widget=forms.MultipleHiddenInput
-            )
         super(UserTermsAndConditionsModelForm, self).__init__(*args, **kwargs)
 
 

--- a/termsandconditions/models.py
+++ b/termsandconditions/models.py
@@ -110,6 +110,8 @@ class TermsAndConditions(models.Model):
             return True
         except UserTermsAndConditions.DoesNotExist:
             return False
+        except TypeError:
+            return False
 
     @staticmethod
     def agreed_to_terms(user, terms=None):
@@ -119,4 +121,6 @@ class TermsAndConditions(models.Model):
             UserTermsAndConditions.objects.get(user=user, terms=terms)
             return True
         except UserTermsAndConditions.DoesNotExist:
+            return False
+        except TypeError:
             return False

--- a/termsandconditions/static/termsandconditions/css/modal.css
+++ b/termsandconditions/static/termsandconditions/css/modal.css
@@ -5,7 +5,7 @@
     width: 500px;
     margin-left: -250px;
     z-index: 1000;
-    background: #fff;
+    background: #ffffff;
     box-shadow: 0 -1px 10px 1px rgba(0, 0, 0, 0.3);
 }
 
@@ -39,16 +39,21 @@
 }
 
 #termsandconditions #toc-header .toc-close:hover {
-    color: lightgray;
+    color: #d3d3d3;
+    text-decoration: none;
 }
 
 #termsandconditions #toc-content #toc-body {
     padding: 15px 0;
 }
 
+#termsandconditions #toc-content #toc-body a:hover {
+    text-decoration: underline;
+}
+
 #termsandconditions #toc-content #toc-footer {
     width: 100%;
-    border-top: 1px lightgray solid;
+    border-top: 1px #d3d3d3 solid;
 }
 
 #termsandconditions #toc-content #toc-footer .toc-accept-all-btn {
@@ -61,7 +66,8 @@
 }
 
 #termsandconditions #toc-content #toc-footer .toc-accept-all-btn:hover {
-    background-color: lightgray;
+    background-color: #d3d3d3;
+    text-decoration: none;
 }
 
 @media(max-width: 500px) {

--- a/termsandconditions/static/termsandconditions/css/modal.css
+++ b/termsandconditions/static/termsandconditions/css/modal.css
@@ -1,65 +1,73 @@
-.termsandconditions-modal {
-  visibility: hidden;
-  position: fixed;
-  z-index: 100;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  font-family: Arial, Helvetica, sans-serif;
-  text-align:center;
-  z-index: 999;
-  background: rgba(4, 10, 30, 0.8);
-  -moz-transition: all 0.5s ease-out;
-  -webkit-transition: all 0.5s ease-out;
-  -o-transition: all 0.5s ease-out;
-  transition: all 0.5s ease-out;
+#termsandconditions {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    width: 500px;
+    margin-left: -250px;
+    z-index: 1000;
+    background: #fff;
+    box-shadow: 0 -1px 10px 1px rgba(0, 0, 0, 0.3);
 }
 
-.termsandconditions-modal div {
-  poistion: absolute;
-  z-index: 1000;
-  top: 33%;
-  left: 25%;
-  width: 50%;
-  margin: 10% auto;
-  padding: 5px 20px 13px 20px;
-  -moz-border-radius: 10px;
-  -webkit-border-radius: 10px;
-  border-radius: 10px;
-  background: #ffffff;
-  background: -moz-linear-gradient(#ffffff, #cccccc);
-  background: -webkit-linear-gradient(#ffffff, #cccccc);
-  background: -o-linear-gradient(#ffffff, #cccccc);
-  box-shadow: 0 0 10px #000000;
-  -moz-box-shadow: 0 0 10px #000000;
-  -webkit-box-shadow: 0 0 10px #000000;
+#termsandconditions #toc-content {
+    margin: 0 15px;
 }
 
-.termsandconditions-close {
-  display: block;
-  background: #606061;
-  color: #FFFFFF;
-  line-height: 25px;
-  position: relative;
-  left: -32px;
-  top: -16px;
-  width: 24px;
-  text-align: center;
-  text-decoration: none;
-  font-weight: bold;
-  -webkit-border-radius: 12px;
-  -moz-border-radius: 12px;
-  border-radius: 12px;
-  box-shadow: 0 0 10px #000000;
-  -moz-box-shadow: 0 0 10px #000000;
-  -webkit-box-shadow: 0 0 10px #000000;
+#termsandconditions #toc-header {
+    position: relative;
+    background-color: #0a62a9;
+    color: #ffffff;
+    margin: 0;
+    padding: 12px 15px;
 }
 
-.termsandconditions-close:hover {
-  background: #bd362f;
+#termsandconditions #toc-header h6 {
+    color: #ffffff;
+    margin: 0;
+    font-size: 18px;
+    font-weight: 400;
 }
 
-body {
-  height:100%;
+#termsandconditions #toc-header .toc-close {
+    position: absolute;
+    top: 50%;
+    margin-top: -14px;
+    right: 15px;
+    color: #ffffff;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+#termsandconditions #toc-header .toc-close:hover {
+    color: lightgray;
+}
+
+#termsandconditions #toc-content #toc-body {
+    padding: 15px 0;
+}
+
+#termsandconditions #toc-content #toc-footer {
+    width: 100%;
+    border-top: 1px lightgray solid;
+}
+
+#termsandconditions #toc-content #toc-footer .toc-accept-all-btn {
+    float: right;
+    margin: 10px 0;
+    font-weight: 600;
+    color: #0a62a9;
+    padding: 8px 10px;
+    border-radius: 5px;
+}
+
+#termsandconditions #toc-content #toc-footer .toc-accept-all-btn:hover {
+    background-color: lightgray;
+}
+
+@media(max-width: 500px) {
+    #termsandconditions {
+        width: 100%;
+        margin-left: 0;
+        left: 0;
+    }
 }

--- a/termsandconditions/static/termsandconditions/css/view_accept.css
+++ b/termsandconditions/static/termsandconditions/css/view_accept.css
@@ -1,0 +1,11 @@
+.toc-container {
+    border: 2px solid lightgray;
+    padding: 10px 20px;
+    max-height: 400px;
+    overflow: auto;
+    margin-bottom: 20px;
+}
+
+.toc-print-container {
+    margin: 0 50px;
+}

--- a/termsandconditions/templates/termsandconditions/snippets/termsandconditions.html
+++ b/termsandconditions/templates/termsandconditions/snippets/termsandconditions.html
@@ -1,7 +1,7 @@
 {% load staticfiles %}
 {% load i18n %}
 
-{% if terms %}
+{% if not_agreed_terms %}
     <link rel="stylesheet" type="text/css" href="{% static 'termsandconditions/css/modal.css' %}">
     <script src="{% static 'termsandconditions/js/modal.js' %}" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript">
@@ -11,18 +11,23 @@
     </script>
 
     <div id="termsandconditions" class="termsandconditions-modal">
-        <div>
-        <a href='javascript:void(0)' onclick='termsandconditions_overlay();' title="{% trans 'Close' %}" class="termsandconditions-close">X</a>
-        <h2>
-            {% if terms.name %}
-                {{ terms.name|safe }}
-            {% else %}
-                {% trans 'Terms and Conditions' %}
-            {% endif %}
-        </h2>
-            {% if terms.info %}{{ terms.info|safe }}{% endif %}
-            {% trans 'To accept new Terms, visit' %}
-            <a href="{% url 'tc_accept_specific_page' terms.slug %}">{% url 'tc_accept_specific_page' terms.slug %}</a>
+        <div id="toc-header">
+            <h6>Our Terms and Conditions Have Changed</h6>
+            <a href='javascript:void(0)' onclick='termsandconditions_overlay();' title="{% trans 'Close' %}" class="toc-close">&times;</a>
+        </div>
+        <div id="toc-content">
+            <div id="toc-body">
+                <span>Changes have been made to our </span>
+                {% for terms in not_agreed_terms %}
+                    {% if not forloop.first and not forloop.last %}<span>, </span>{% endif %}
+                    {% if forloop.last and not_agreed_terms|length > 2 %}<span>, and </span>{% elif forloop.last %}<span> and </span>{% endif %}
+                    <a class="terms-link" href="{% url 'tc_accept_specific_page' terms.slug %}">{% if terms.name %}{{ terms.name|safe }}{% endif %}</a>
+                {% endfor %}
+                <span> document{{ not_agreed_terms|length|pluralize }}. Please, review and accept the changes to prevent future interruption.</span>
+            </div>
+            <div id="toc-footer">
+                <a class="toc-accept-all-btn" href="">{% trans 'ACCEPT ALL' %}</a>
+            </div>
         </div>
     </div>
 {% endif %}

--- a/termsandconditions/templates/termsandconditions/snippets/termsandconditions.html
+++ b/termsandconditions/templates/termsandconditions/snippets/termsandconditions.html
@@ -20,13 +20,13 @@
                 <span>Changes have been made to our </span>
                 {% for terms in not_agreed_terms %}
                     {% if not forloop.first and not forloop.last %}<span>, </span>{% endif %}
-                    {% if forloop.last and not_agreed_terms|length > 2 %}<span>, and </span>{% elif forloop.last %}<span> and </span>{% endif %}
+                    {% if forloop.last and not_agreed_terms|length > 2 %}<span>, and </span>{% elif forloop.last and not_agreed_terms|length > 1 %}<span> and </span>{% endif %}
                     <a class="terms-link" href="{% url 'tc_accept_specific_page' terms.slug %}">{% if terms.name %}{{ terms.name|safe }}{% endif %}</a>
                 {% endfor %}
-                <span> document{{ not_agreed_terms|length|pluralize }}. Please, review and accept the changes to prevent future interruption.</span>
+                <span> document{{ not_agreed_terms|length|pluralize }}. Please, review and accept the changes to prevent future interruptions.</span>
             </div>
             <div id="toc-footer">
-                <a class="toc-accept-all-btn" href="">{% trans 'ACCEPT ALL' %}</a>
+                <a class="toc-accept-all-btn" href="{% url 'tc_accept_page' %}">{% trans 'ACCEPT ALL' %}</a>
             </div>
         </div>
     </div>

--- a/termsandconditions/templates/termsandconditions/snippets/termsandconditions.html
+++ b/termsandconditions/templates/termsandconditions/snippets/termsandconditions.html
@@ -21,12 +21,12 @@
                 {% for terms in not_agreed_terms %}
                     {% if not forloop.first and not forloop.last %}<span>, </span>{% endif %}
                     {% if forloop.last and not_agreed_terms|length > 2 %}<span>, and </span>{% elif forloop.last and not_agreed_terms|length > 1 %}<span> and </span>{% endif %}
-                    <a class="terms-link" href="{% url 'tc_accept_specific_page' terms.slug %}">{% if terms.name %}{{ terms.name|safe }}{% endif %}</a>
+                    <a class="terms-link" href="{% url 'tc_accept_specific_page' terms.slug %}{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">{% if terms.name %}{{ terms.name|safe }}{% endif %}</a>
                 {% endfor %}
                 <span> document{{ not_agreed_terms|length|pluralize }}. Please, review and accept the changes to prevent future interruptions.</span>
             </div>
             <div id="toc-footer">
-                <a class="toc-accept-all-btn" href="{% url 'tc_accept_page' %}">{% trans 'ACCEPT ALL' %}</a>
+                <a class="toc-accept-all-btn" href="{% url 'tc_accept_page' %}{% if returnTo %}?returnTo={{ returnTo }}{% endif %}">{% trans 'ACCEPT ALL' %}</a>
             </div>
         </div>
     </div>

--- a/termsandconditions/templates/termsandconditions/tc_accept_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_accept_terms.html
@@ -1,24 +1,32 @@
 {% extends "page.html" %}
 
-{% block title %}Accept Terms and Conditions{% endblock %}
+{% load staticfiles %}
 
-{# {% block header %}{% endblock %} #}
+{% block title %}Accept Terms and Conditions{% endblock %}
+{% block styles %}
+    {{ block.super }}
+    <link href="{% static 'termsandconditions/css/view_accept.css' %}" rel="stylesheet">
+{% endblock %}
 
 {% block content %}
     <section title="termsandconditions" data-role="content">
-        <h1>Please Accept {{ form.initial.terms.name|safe }}</h1>
         {{ form.errors }}
-        <div id="tc-terms-html">
-            {{ form.initial.terms.text|safe }}
-        </div>
+        {% for terms in form.initial.terms %}
+            <h1>Please Accept {{ terms.name|safe }}</h1>
+            <div class="toc-container">
+                <div id="tc-terms-html">
+                    {{ terms.text|safe }}
+                </div>
+            </div>
+
+            <p><a href="{% url "tc_print_page" terms.slug terms.version_number %}"
+                  target="_blank">Print {{ terms.name }}</a></p>
+        {% endfor %}
         <form action="{% url 'tc_accept_page' %}" method="post" id="tc-terms-form" data-ajax="false">
             {% csrf_token %}
             {{ form.terms }}
             {{ form.returnTo }}
-            <p><input type="submit" value="Accept" data-role="button"></p>
+            <p><input type="submit" value="Accept{% if form.initial.terms|length > 1 %} All{% endif %}" data-role="button"></p>
         </form>
-        <p><a href="{% url "tc_print_page" form.initial.terms.slug form.initial.terms.version_number %}"
-              target="_blank">Print Terms & Conditions</a></p>
     </section>
 {% endblock %}
-{# {% block footer %}{% endblock %} #}

--- a/termsandconditions/templates/termsandconditions/tc_accept_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_accept_terms.html
@@ -9,18 +9,25 @@
 {% endblock %}
 
 {% block content %}
-    <section title="termsandconditions" data-role="content">
+    <section id="termsandconditions-section" title="termsandconditions" data-role="content">
         {{ form.errors }}
         {% for terms in form.initial.terms %}
-            <h1>Please Accept {{ terms.name|safe }}</h1>
+            <h1>Please Accept {{ terms.name|safe }} {{ terms.version_number|safe }}</h1>
+            {% if terms.info %}
+                <h4>Summary of Changes</h4>
+                <div class="toc-container">
+                    {{ terms.info|safe }}
+                </div>
+                <h4>Full Text</h4>
+            {% endif %}
             <div class="toc-container">
                 <div id="tc-terms-html">
                     {{ terms.text|safe }}
                 </div>
             </div>
 
-            <p><a href="{% url "tc_print_page" terms.slug terms.version_number %}"
-                  target="_blank">Print {{ terms.name }}</a></p>
+            <p><a href="{% url "tc_print_page" terms.slug|safe terms.version_number|safe %}"
+                  target="_blank">Print {{ terms.name|safe }}</a></p>
         {% endfor %}
         <form action="{% url 'tc_accept_page' %}" method="post" id="tc-terms-form" data-ajax="false">
             {% csrf_token %}

--- a/termsandconditions/templates/termsandconditions/tc_accept_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_accept_terms.html
@@ -1,4 +1,4 @@
-{% extends "page.html" %}
+{% extends terms_base_template %}
 
 {% load staticfiles %}
 

--- a/termsandconditions/templates/termsandconditions/tc_accept_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_accept_terms.html
@@ -1,8 +1,8 @@
-{% extends "base.html" %}
+{% extends "page.html" %}
 
-{% block headtitle %}Accept Terms and Conditions{% endblock %}
+{% block title %}Accept Terms and Conditions{% endblock %}
 
-{% block header %}{% endblock %}
+{# {% block header %}{% endblock %} #}
 
 {% block content %}
     <section title="termsandconditions" data-role="content">
@@ -21,4 +21,4 @@
               target="_blank">Print Terms & Conditions</a></p>
     </section>
 {% endblock %}
-{% block footer %}{% endblock %}
+{# {% block footer %}{% endblock %} #}

--- a/termsandconditions/templates/termsandconditions/tc_email_terms_form.html
+++ b/termsandconditions/templates/termsandconditions/tc_email_terms_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "page.html" %}
 
 {% block headtitle %}Email Terms and Conditions{% endblock %}
 

--- a/termsandconditions/templates/termsandconditions/tc_email_terms_form.html
+++ b/termsandconditions/templates/termsandconditions/tc_email_terms_form.html
@@ -1,4 +1,4 @@
-{% extends "page.html" %}
+{% extends terms_base_template %}
 
 {% block headtitle %}Email Terms and Conditions{% endblock %}
 

--- a/termsandconditions/templates/termsandconditions/tc_print_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_print_terms.html
@@ -1,8 +1,8 @@
-{% extends 'page.html' %}
+{% extends terms_base_template %}
 
 {% load staticfiles %}
 
-{% block headtitle %}Print Terms and Conditions{% endblock %}
+{% block title %}Print Terms and Conditions{% endblock %}
 
 {% block body_class %}{% endblock %}
 

--- a/termsandconditions/templates/termsandconditions/tc_print_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_print_terms.html
@@ -1,24 +1,36 @@
 {% extends 'page.html' %}
 
+{% load staticfiles %}
+
 {% block headtitle %}Print Terms and Conditions{% endblock %}
 
 {% block body_class %}{% endblock %}
 
+{% block styles %}
+    {{ block.super }}
+    <link href="{% static 'termsandconditions/css/view_accept.css' %}" rel="stylesheet">
+{% endblock %}
+
 {% block head %}
     <script>
-        window.print();
+        document.addEventListener("DOMContentLoaded", function(event) {
+            window.print();
+        });
     </script>
 {% endblock %}
 
 {% block header %}{% endblock %}
 
 {% block content %}
-    <h1>{{ terms.name|safe }}</h1>
-    <h3>Version {{ terms.version_number|safe }}</h3>
-
-    <div>
-        {{ terms.text|safe }}
-    </div>
+    {% for terms in terms_list %}
+        <div class="toc-print-container">
+            <h1>{{ terms.name|safe }}</h1>
+            <h3>Version {{ terms.version_number|safe }}</h3>
+            <div>
+                {{ terms.text|safe }}
+            </div>
+        </div>
+    {% endfor %}
 {% endblock %}
 
 {% block footer %}{% endblock %}

--- a/termsandconditions/templates/termsandconditions/tc_print_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_print_terms.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'page.html' %}
 
 {% block headtitle %}Print Terms and Conditions{% endblock %}
 

--- a/termsandconditions/templates/termsandconditions/tc_view_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_view_terms.html
@@ -1,11 +1,22 @@
 {% extends 'page.html' %}
 
+{% load staticfiles %}
+
+{% block styles %}
+    {{ block.super }}
+    <link href="{% static 'termsandconditions/css/view_accept.css' %}" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
     <section title="Terms and Conditions" data-role="content">
-        <h1>{{ terms.name|safe }}</h1>
+        {% for terms in terms_list %}
+            <h1>{{ terms.name|safe }}</h1>
 
-        <div>
-            {{ terms.text|safe }}
-        </div>
+            <div class="toc-container">
+                {{ terms.text|safe }}
+            </div>
+            <p><a href="{% url "tc_print_page" terms.slug terms.version_number %}"
+                      target="_blank">Print {{ terms.name }}</a></p>
+        {% endfor %}
     </section>
 {% endblock %}

--- a/termsandconditions/templates/termsandconditions/tc_view_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_view_terms.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'page.html' %}
 
 {% block content %}
     <section title="Terms and Conditions" data-role="content">

--- a/termsandconditions/templates/termsandconditions/tc_view_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_view_terms.html
@@ -2,6 +2,7 @@
 
 {% load staticfiles %}
 
+{% block title %}View Terms and Conditions{% endblock %}
 {% block styles %}
     {{ block.super }}
     <link href="{% static 'termsandconditions/css/view_accept.css' %}" rel="stylesheet">

--- a/termsandconditions/templates/termsandconditions/tc_view_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_view_terms.html
@@ -10,13 +10,13 @@
 {% block content %}
     <section title="Terms and Conditions" data-role="content">
         {% for terms in terms_list %}
-            <h1>{{ terms.name|safe }}</h1>
+            <h1>{{ terms.name|safe }} {{ terms.version_number|safe }}</h1>
 
             <div class="toc-container">
                 {{ terms.text|safe }}
             </div>
-            <p><a href="{% url "tc_print_page" terms.slug terms.version_number %}"
-                      target="_blank">Print {{ terms.name }}</a></p>
+            <p><a href="{% url "tc_print_page" terms.slug|safe terms.version_number|safe %}"
+                      target="_blank">Print {{ terms.name|safe }}</a></p>
         {% endfor %}
     </section>
 {% endblock %}

--- a/termsandconditions/templates/termsandconditions/tc_view_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_view_terms.html
@@ -1,4 +1,4 @@
-{% extends 'page.html' %}
+{% extends terms_base_template %}
 
 {% load staticfiles %}
 

--- a/termsandconditions/templatetags/terms_tags.py
+++ b/termsandconditions/templatetags/terms_tags.py
@@ -43,6 +43,6 @@ def show_terms_if_not_agreed(context, slug=DEFAULT_TERMS_SLUG, field=TERMS_HTTP_
     protected = is_path_protected(url.path)
 
     if (not all_agreed) and not_agreed_terms and protected:
-        return {'not_agreed_terms': not_agreed_terms}
+        return {'not_agreed_terms': not_agreed_terms, 'returnTo': url.path}
 
     return {}

--- a/termsandconditions/views.py
+++ b/termsandconditions/views.py
@@ -18,6 +18,9 @@ import logging
 from smtplib import SMTPException
 
 LOGGER = logging.getLogger(name='termsandconditions')
+DEFAULT_TERMS_BASE_TEMPLATE = 'base.html'
+DEFAULT_ACCEPT_TERMS_OVERRIDE_HEADER_BLOCK = True
+DEFAULT_ACCEPT_TERMS_OVERRIDE_FOOTER_BLOCK = True
 
 
 class GetTermsViewMixin(object):
@@ -49,6 +52,12 @@ class TermsView(DetailView, GetTermsViewMixin):
     template_name = "termsandconditions/tc_view_terms.html"
     context_object_name = 'terms_list'
 
+    def get_context_data(self, **kwargs):
+        """Pass additional context data"""
+        context = super(TermsView, self).get_context_data(**kwargs)
+        context['terms_base_template'] = getattr(settings, 'TERMS_BASE_TEMPLATE', DEFAULT_TERMS_BASE_TEMPLATE)
+        return context
+
     def get_object(self, queryset=None):
         """Override of DetailView method, queries for which T&C to return"""
         LOGGER.debug('termsandconditions.views.TermsView.get_object')
@@ -65,6 +74,16 @@ class AcceptTermsView(CreateView, GetTermsViewMixin):
     model = UserTermsAndConditions
     form_class = UserTermsAndConditionsModelForm
     template_name = "termsandconditions/tc_accept_terms.html"
+
+    def get_context_data(self, **kwargs):
+        """Pass additional context data"""
+        context = super(AcceptTermsView, self).get_context_data(**kwargs)
+        context['terms_base_template'] = getattr(settings, 'TERMS_BASE_TEMPLATE', DEFAULT_TERMS_BASE_TEMPLATE)
+        context['terms_header_block'] = getattr(settings, 'TERMS_HEADER_BLOCK', DEFAULT_TERMS_HEADER_BLOCK)
+        context['terms_content_block'] = getattr(settings, 'TERMS_CONTENT_BLOCK', DEFAULT_TERMS_CONTENT_BLOCK)
+        context['terms_footer_block'] = getattr(settings, 'TERMS_FOOTER_BLOCK', DEFAULT_TERMS_FOOTER_BLOCK)
+        context['terms_styles_block'] = getattr(settings, 'TERMS_STYLES_BLOCK', DEFAULT_TERMS_STYLES_BLOCK)
+        return context
 
     def get_initial(self):
         """Override of CreateView method, queries for which T&C to accept and catches returnTo from URL"""
@@ -124,6 +143,16 @@ class EmailTermsView(FormView, GetTermsViewMixin):
     template_name = "termsandconditions/tc_email_terms_form.html"
 
     form_class = EmailTermsForm
+
+    def get_context_data(self, **kwargs):
+        """Pass additional context data"""
+        context = super(EmailTermsView, self).get_context_data(**kwargs)
+        context['terms_base_template'] = getattr(settings, 'TERMS_BASE_TEMPLATE', DEFAULT_TERMS_BASE_TEMPLATE)
+        context['terms_header_block'] = getattr(settings, 'TERMS_HEADER_BLOCK', DEFAULT_TERMS_HEADER_BLOCK)
+        context['terms_content_block'] = getattr(settings, 'TERMS_CONTENT_BLOCK', DEFAULT_TERMS_CONTENT_BLOCK)
+        context['terms_footer_block'] = getattr(settings, 'TERMS_FOOTER_BLOCK', DEFAULT_TERMS_FOOTER_BLOCK)
+        context['terms_styles_block'] = getattr(settings, 'TERMS_STYLES_BLOCK', DEFAULT_TERMS_STYLES_BLOCK)
+        return context
 
     def get_initial(self):
         """Override of CreateView method, queries for which T&C send, catches returnTo from URL"""

--- a/termsandconditions/views.py
+++ b/termsandconditions/views.py
@@ -19,8 +19,6 @@ from smtplib import SMTPException
 
 LOGGER = logging.getLogger(name='termsandconditions')
 DEFAULT_TERMS_BASE_TEMPLATE = 'base.html'
-DEFAULT_ACCEPT_TERMS_OVERRIDE_HEADER_BLOCK = True
-DEFAULT_ACCEPT_TERMS_OVERRIDE_FOOTER_BLOCK = True
 
 
 class GetTermsViewMixin(object):
@@ -79,10 +77,6 @@ class AcceptTermsView(CreateView, GetTermsViewMixin):
         """Pass additional context data"""
         context = super(AcceptTermsView, self).get_context_data(**kwargs)
         context['terms_base_template'] = getattr(settings, 'TERMS_BASE_TEMPLATE', DEFAULT_TERMS_BASE_TEMPLATE)
-        context['terms_header_block'] = getattr(settings, 'TERMS_HEADER_BLOCK', DEFAULT_TERMS_HEADER_BLOCK)
-        context['terms_content_block'] = getattr(settings, 'TERMS_CONTENT_BLOCK', DEFAULT_TERMS_CONTENT_BLOCK)
-        context['terms_footer_block'] = getattr(settings, 'TERMS_FOOTER_BLOCK', DEFAULT_TERMS_FOOTER_BLOCK)
-        context['terms_styles_block'] = getattr(settings, 'TERMS_STYLES_BLOCK', DEFAULT_TERMS_STYLES_BLOCK)
         return context
 
     def get_initial(self):
@@ -148,10 +142,6 @@ class EmailTermsView(FormView, GetTermsViewMixin):
         """Pass additional context data"""
         context = super(EmailTermsView, self).get_context_data(**kwargs)
         context['terms_base_template'] = getattr(settings, 'TERMS_BASE_TEMPLATE', DEFAULT_TERMS_BASE_TEMPLATE)
-        context['terms_header_block'] = getattr(settings, 'TERMS_HEADER_BLOCK', DEFAULT_TERMS_HEADER_BLOCK)
-        context['terms_content_block'] = getattr(settings, 'TERMS_CONTENT_BLOCK', DEFAULT_TERMS_CONTENT_BLOCK)
-        context['terms_footer_block'] = getattr(settings, 'TERMS_FOOTER_BLOCK', DEFAULT_TERMS_FOOTER_BLOCK)
-        context['terms_styles_block'] = getattr(settings, 'TERMS_STYLES_BLOCK', DEFAULT_TERMS_STYLES_BLOCK)
         return context
 
     def get_initial(self):

--- a/termsandconditions/views.py
+++ b/termsandconditions/views.py
@@ -3,6 +3,9 @@
 # pylint: disable=E1120,R0901,R0904
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError
+from django.shortcuts import render
+
 from .forms import UserTermsAndConditionsModelForm, EmailTermsForm
 from .models import TermsAndConditions, UserTermsAndConditions, DEFAULT_TERMS_SLUG
 from django.conf import settings
@@ -17,34 +20,42 @@ from smtplib import SMTPException
 LOGGER = logging.getLogger(name='termsandconditions')
 
 
-def get_terms(kwargs):
-    """Checks URL parameters for slug and/or version to pull the right TermsAndConditions object"""
-    slug = kwargs.get("slug", DEFAULT_TERMS_SLUG)
+class GetTermsViewMixin(object):
+    def get_terms(self, kwargs):
+        """Checks URL parameters for slug and/or version to pull the right TermsAndConditions object"""
 
-    if kwargs.get("version"):
-        terms = TermsAndConditions.objects.get(slug=slug, version_number=kwargs.get("version"))
-    else:
-        terms = TermsAndConditions.get_active(slug)
-    return terms
+        slug = kwargs.get("slug")
+        version = kwargs.get("version")
+
+        if slug and version:
+            terms = [TermsAndConditions.objects.get(slug=slug, version_number=version)]
+        elif slug:
+            terms = [TermsAndConditions.get_active(slug)]
+        else:
+            # Return a list of not agreed to terms for the list view
+            terms = []
+            for terms_slug, active_terms in TermsAndConditions.get_active_list().iteritems():
+                if not TermsAndConditions.agreed_to_terms(self.request.user, active_terms):
+                    terms.append(active_terms)
+        return terms
 
 
-class TermsView(DetailView):
+class TermsView(DetailView, GetTermsViewMixin):
     """
     View Terms and Conditions View
 
     url: /terms/view
     """
     template_name = "termsandconditions/tc_view_terms.html"
-    context_object_name = 'terms'
+    context_object_name = 'terms_list'
 
     def get_object(self, queryset=None):
         """Override of DetailView method, queries for which T&C to return"""
         LOGGER.debug('termsandconditions.views.TermsView.get_object')
+        return self.get_terms(self.kwargs)
 
-        return get_terms(self.kwargs)
 
-
-class AcceptTermsView(CreateView):
+class AcceptTermsView(CreateView, GetTermsViewMixin):
     """
     Terms and Conditions Acceptance view
 
@@ -59,30 +70,56 @@ class AcceptTermsView(CreateView):
         """Override of CreateView method, queries for which T&C to accept and catches returnTo from URL"""
         LOGGER.debug('termsandconditions.views.AcceptTermsView.get_initial')
 
-        terms = get_terms(self.kwargs)
-
+        terms = self.get_terms(self.kwargs)
         returnTo = self.request.GET.get('returnTo', '/')
 
         return {'terms': terms, 'returnTo': returnTo}
 
-    def form_valid(self, form):
-        """Override of CreateView method, assigns default values based on user situation"""
-        if self.request.user.is_authenticated():
-            form.instance.user = self.request.user
-        else:  #Get user out of saved pipeline from django-socialauth
-            if self.request.session.has_key('partial_pipeline'):
-                user_pk = self.request.session['partial_pipeline']['kwargs']['user']['pk']
-                form.instance.user = User.objects.get(id=user_pk)
+    def post(self, request, *args, **kwargs):
+        """
+        Handles POST request.
+        """
+        form = self.form_class(request.POST)
+        print(form.is_valid())
+
+        if form.is_valid():
+            return_url = form.cleaned_data.get('returnTo', '/') or '/'
+            terms_ids = request.POST.getlist('terms')
+            print(terms_ids)
+
+            if request.user.is_authenticated():
+                user = request.user
             else:
-                return HttpResponseRedirect('/')
-        store_ip_address = getattr(settings, 'TERMS_STORE_IP_ADDRESS', True)
-        if store_ip_address:
-            form.instance.ip_address = self.request.META['REMOTE_ADDR']
-        self.success_url = form.cleaned_data.get('returnTo', '/') or '/'
-        return super(AcceptTermsView, self).form_valid(form)
+                # Get user out of saved pipeline from django-socialauth
+                if request.session.has_key('partial_pipeline'):
+                    user_pk = request.session['partial_pipeline']['kwargs']['user']['pk']
+                    user = User.objects.get(id=user_pk)
+                else:
+                    return HttpResponseRedirect('/')
+
+            store_ip_address = getattr(settings, 'TERMS_STORE_IP_ADDRESS', True)
+            if store_ip_address:
+                ip_address = request.META['REMOTE_ADDR']
+            else:
+                ip_address = ""
+
+            for terms_id in terms_ids:
+                try:
+                    new_user_terms = UserTermsAndConditions(
+                        user=user,
+                        terms=TermsAndConditions.objects.get(pk=int(terms_id)),
+                        ip_address=ip_address
+                    )
+                    new_user_terms.save()
+                except IntegrityError:
+                    pass
+
+            return HttpResponseRedirect(return_url)
+
+        return render(request, self.template_name, {'form': form})
 
 
-class EmailTermsView(FormView):
+class EmailTermsView(FormView, GetTermsViewMixin):
     """
     Email Terms and Conditions View
 
@@ -96,7 +133,7 @@ class EmailTermsView(FormView):
         """Override of CreateView method, queries for which T&C send, catches returnTo from URL"""
         LOGGER.debug('termsandconditions.views.EmailTermsView.get_initial')
 
-        terms = get_terms(self.kwargs)
+        terms = self.get_terms(self.kwargs)
 
         returnTo = self.request.GET.get('returnTo', '/')
 


### PR DESCRIPTION
I've made some significant enhancements that may or may not be of interest. Major changes include:
- Improved appearance and behavior of the modal
- Ability to accept multiple terms and conditions documents simultaneously For example, if you have documents with differing slugs 'privacy-policy' and 'site-terms' and both have not been agreed to, these will now be listed individually in the modal with an "Accept All' button that takes you to the '/terms/accept/' endpoint, which now shows both documents if not not agreed with an 'Accept All' button.
- Significant changes to the UserTermsAndConditionsModelForm and AcceptTermsView to allow the handling of multi-conditions acceptance in a single form.
- Changes to some of the UserTermsAndConditions methods and and refactoring where used to better facilitate multi-conditions acceptance.
- New setting to specify which base template is extended in T&C templates (e.g. 'page.html' instead of 'base.html')

All but two tests are passing at the time of the pull request. I've taken a look at them, but it is not apparent to my why they are failing. Seems to me it may be subtle point with how the tests are setup that I'm missing.