### PR TITLE
Moved searching for active terms into form initializer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=('termsandconditions_demo', 'tests', 'devscripts')),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['django>=1.8.3', ],
+    install_requires=['django>=1.8.3', 'future>=0.15.2'],
 
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/termsandconditions/forms.py
+++ b/termsandconditions/forms.py
@@ -10,7 +10,7 @@ class UserTermsAndConditionsModelForm(forms.Form):
     """Form used when accepting Terms and Conditions - returnTo is used to catch where to end up."""
     returnTo = forms.CharField(required=False, initial="/", widget=forms.HiddenInput())
     terms = forms.ModelMultipleChoiceField(
-        TermsAndConditions.get_active_list(as_dict=False),
+        TermsAndConditions.objects.none(),
         widget=forms.MultipleHiddenInput,
     )
 
@@ -18,14 +18,21 @@ class UserTermsAndConditionsModelForm(forms.Form):
         if 'instance' in kwargs:
             kwargs.pop('instance')
 
+        terms_list = None
+
         if 'initial' in kwargs:
             initial = kwargs.get('initial')
 
             if 'terms' in initial:
-                self.terms = forms.ModelMultipleChoiceField(
-                    initial.get('terms'),
-                    widget=forms.MultipleHiddenInput,
-                )
+                terms_list = initial.get('terms')
+
+        if terms_list is None:
+            terms_list = TermsAndConditions.get_active_list(as_dict=False)
+
+        self.terms = forms.ModelMultipleChoiceField(
+            terms_list,
+            widget=forms.MultipleHiddenInput)
+
         super(UserTermsAndConditionsModelForm, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
This prevents database access during package loading, as well
as ensures that the form will always have correct values at hand.

Loading the list of terms during class loading might have lead
to a situation where new terms were not visible in the form.