### PR TITLE
Update urls.py to enable namespaces.

### DIFF
--- a/termsandconditions/urls.py
+++ b/termsandconditions/urls.py
@@ -10,6 +10,8 @@ from django.contrib import admin
 from .views import TermsView, AcceptTermsView, EmailTermsView
 from .models import DEFAULT_TERMS_SLUG
 
+app_name = 'terms_and_conditions'
+
 admin.autodiscover()
 
 urlpatterns = (


### PR DESCRIPTION
Hi There,

In Django 2.x, the urls file needs a specified app_name in order to use namespaces in template url links.

ie: {% url "terms_and_conditions:tc_view_page" %}

This little addition fixes the issue.

Thanks!