### PR TITLE
URLs to Django 2+ Standard, Handle No Terms

### DIFF
--- a/termsandconditions/templates/termsandconditions/tc_view_terms.html
+++ b/termsandconditions/templates/termsandconditions/tc_view_terms.html
@@ -12,13 +12,19 @@
 {% block content %}
     <section title="{% trans 'Terms and Conditions' %}" data-role="content">
         {% for terms in terms_list %}
-            <h1>{{ terms.name|safe }} {{ terms.version_number|safe }}</h1>
+            {% if terms %}
+                <h1>{{ terms.name|safe }} {{ terms.version_number|safe }}</h1>
 
-            <div class="toc-container">
-                {{ terms.text|safe }}
-            </div>
-            <p><a href="{% url 'tc_print_page' terms.slug|safe terms.version_number|safe %}"
+                <div class="toc-container">
+                    {{ terms.text|safe }}
+                </div>
+                <p><a href="{% url 'tc_print_page' terms.slug|safe terms.version_number|safe %}"
                       target="_blank">{% trans 'Print' %} {{ terms.name|safe }}</a></p>
+            {% else %}
+                <h1>No terms defined.</h1>
+            {% endif %}
+        {% empty %}
+                <h1>No terms defined.</h1>
         {% endfor %}
     </section>
 {% endblock %}

--- a/termsandconditions/tests.py
+++ b/termsandconditions/tests.py
@@ -173,7 +173,7 @@ class TermsAndConditionsTests(TestCase):
         LOGGER.debug("Test /secure/ after login")
         logged_in_response = self.client.get("/secure/", follow=True)
         self.assertRedirects(
-            logged_in_response, "/terms/accept/contrib-terms?returnTo=/secure/"
+            logged_in_response, "/terms/accept/contrib-terms/?returnTo=/secure/"
         )
 
     def test_terms_required_redirect(self):
@@ -289,7 +289,7 @@ class TermsAndConditionsTests(TestCase):
         LOGGER.debug("Test user1 is redirected when changing pages")
         post_upgrade_response = self.client.get("/secure/", follow=True)
         self.assertRedirects(
-            post_upgrade_response, "/terms/accept/site-terms?returnTo=/secure/"
+            post_upgrade_response, "/terms/accept/site-terms/?returnTo=/secure/"
         )
 
     def test_no_middleware(self):

--- a/termsandconditions/urls.py
+++ b/termsandconditions/urls.py
@@ -5,53 +5,70 @@
 
 # pylint: disable=W0401, W0614, E1120
 
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path, register_converter
+
 from .views import TermsView, AcceptTermsView, EmailTermsView
 from .models import DEFAULT_TERMS_SLUG
 
 admin.autodiscover()
 
+
+class TermsVersionConverter:
+    """
+    Registers Django URL path converter for Terms Version Numbers
+    """
+    regex = "[0-9.]+"
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value
+
+
+register_converter(TermsVersionConverter, 'termsversion')
+
 urlpatterns = (
     # View Default Terms
-    url(r"^$", TermsView.as_view(), {"slug": DEFAULT_TERMS_SLUG}, name="tc_view_page"),
+    path("", TermsView.as_view(), {"slug": DEFAULT_TERMS_SLUG}, name="tc_view_page"),
     # View Specific Active Terms
-    url(
-        r"^view/(?P<slug>[a-zA-Z0-9_.-]+)/$",
+    path(
+        "view/<slug:slug>/",
         TermsView.as_view(),
         name="tc_view_specific_page",
     ),
     # View Specific Version of Terms
-    url(
-        r"^view/(?P<slug>[a-zA-Z0-9_.-]+)/(?P<version>[0-9.]+)/$",
+    path(
+        "view/<slug:slug>/<termsversion:version>/",
         TermsView.as_view(),
         name="tc_view_specific_version_page",
     ),
     # Print Specific Version of Terms
-    url(
-        r"^print/(?P<slug>[a-zA-Z0-9_.-]+)/(?P<version>[0-9.]+)/$",
+    path(
+        "print/<slug:slug>/<termsversion:version>/",
         TermsView.as_view(template_name="termsandconditions/tc_print_terms.html"),
         name="tc_print_page",
     ),
     # Accept Terms
-    url(r"^accept/$", AcceptTermsView.as_view(), name="tc_accept_page"),
+    path("accept/", AcceptTermsView.as_view(), name="tc_accept_page"),
     # Accept Specific Terms
-    url(
-        r"^accept/(?P<slug>[a-zA-Z0-9_.-]+)$",
+    path(
+        "accept/<termsversion:slug>/",
         AcceptTermsView.as_view(),
         name="tc_accept_specific_page",
     ),
     # Accept Specific Terms Version
-    url(
-        r"^accept/(?P<slug>[a-zA-Z0-9_.-]+)/(?P<version>[0-9\.]+)/$",
+    path(
+        "accept/<slug:slug>/<termsversion:version>/",
         AcceptTermsView.as_view(),
         name="tc_accept_specific_version_page",
     ),
     # Email Terms
-    url(r"^email/$", EmailTermsView.as_view(), name="tc_email_page"),
+    path("email/", EmailTermsView.as_view(), name="tc_email_page"),
     # Email Specific Terms Version
-    url(
-        r"^email/(?P<slug>[a-zA-Z0-9_.-]+)/(?P<version>[0-9\.]+)/$",
+    path(
+        "email/<slug:slug>/<termsversion:version>/",
         EmailTermsView.as_view(),
         name="tc_specific_version_page",
     ),

--- a/termsandconditions/urls.py
+++ b/termsandconditions/urls.py
@@ -31,7 +31,7 @@ register_converter(TermsVersionConverter, 'termsversion')
 
 urlpatterns = (
     # View Default Terms
-    path("", TermsView.as_view(), {"slug": DEFAULT_TERMS_SLUG}, name="tc_view_page"),
+    path("", TermsView.as_view(), name="tc_view_page"),
     # View Specific Active Terms
     path(
         "view/<slug:slug>/",

--- a/termsandconditions/urls.py
+++ b/termsandconditions/urls.py
@@ -54,7 +54,7 @@ urlpatterns = (
     path("accept/", AcceptTermsView.as_view(), name="tc_accept_page"),
     # Accept Specific Terms
     path(
-        "accept/<termsversion:slug>/",
+        "accept/<slug:slug>/",
         AcceptTermsView.as_view(),
         name="tc_accept_specific_page",
     ),

--- a/termsandconditions/views.py
+++ b/termsandconditions/views.py
@@ -9,7 +9,7 @@ from .models import TermsAndConditions, UserTermsAndConditions
 from django.conf import settings
 from django.core.mail import send_mail
 from django.contrib import messages
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.utils.translation import gettext as _
 from django.views.generic import DetailView, CreateView, FormView
 from django.template.loader import get_template
@@ -57,6 +57,9 @@ class TermsView(DetailView, GetTermsViewMixin):
     def get_context_data(self, **kwargs):
         """Pass additional context data"""
         context = super(TermsView, self).get_context_data(**kwargs)
+        if context["terms_list"][0] is None:
+            # TODO: Raise Terms No Defined Instead
+            raise Http404
         context["terms_base_template"] = getattr(
             settings, "TERMS_BASE_TEMPLATE", DEFAULT_TERMS_BASE_TEMPLATE
         )

--- a/termsandconditions/views.py
+++ b/termsandconditions/views.py
@@ -57,9 +57,6 @@ class TermsView(DetailView, GetTermsViewMixin):
     def get_context_data(self, **kwargs):
         """Pass additional context data"""
         context = super(TermsView, self).get_context_data(**kwargs)
-        if context["terms_list"][0] is None:
-            # TODO: Raise Terms No Defined Instead
-            raise Http404
         context["terms_base_template"] = getattr(
             settings, "TERMS_BASE_TEMPLATE", DEFAULT_TERMS_BASE_TEMPLATE
         )

--- a/termsandconditions_demo/urls.py
+++ b/termsandconditions_demo/urls.py
@@ -1,13 +1,14 @@
 """
-    Master URL Pattern List for the application.  Most of the patterns here should be top-level
-    pass-offs to sub-modules, who will have their own urls.py defining actions within.
+    Master path Pattern List for the application.  Most of the patterns here should be top-level
+    pass-offs to sub-modules, who will have their own paths.py defining actions within.
 """
 
 # pylint: disable=E1120
 
-from django.conf.urls import url, include
 from django.contrib import admin
 from django.conf import settings
+from django.urls import path, include
+
 from .views import TermsRequiredView, SecureView, IndexView
 from django.views.generic import RedirectView, TemplateView
 from django.views.decorators.cache import never_cache
@@ -18,48 +19,48 @@ admin.autodiscover()
 
 urlpatterns = (
     # Home Page
-    url(r"^$", never_cache(IndexView.as_view()), name="tc_demo_home_page"),
+    path("", never_cache(IndexView.as_view()), name="tc_demo_home_page"),
     # Home Page
-    url(
-        r"^anon/$",
+    path(
+        "anon/",
         never_cache(IndexView.as_view(template_name="index_anon.html")),
         name="tc_demo_home_anon_page",
     ),  # used for pipeline user test
     # Secure Page
-    url(
-        r"^secure/$",
+    path(
+        "secure/",
         never_cache((login_required(SecureView.as_view()))),
         name="tc_demo_secure_page",
     ),
     # Secure Page Too
-    url(
-        r"^securetoo/$",
+    path(
+        "securetoo/",
         never_cache(login_required(SecureView.as_view(template_name="securetoo.html"))),
         name="tc_demo_secure_page_too",
     ),
     # Terms Required
-    url(
-        r"^termsrequired/$",
+    path(
+        "termsrequired/",
         never_cache(terms_required(login_required(TermsRequiredView.as_view()))),
         name="tc_demo_required_page",
     ),
     # Terms and Conditions
-    url(r"^terms/", include("termsandconditions.urls")),
-    # Auth Urls:
-    url(r"^accounts/", include("django.contrib.auth.urls")),
+    path("terms/", include("termsandconditions.urls")),
+    # Auth paths:
+    path("accounts/", include("django.contrib.auth.urls")),
     # Admin documentation:
-    url(r"^admin/doc/", include("django.contrib.admindocs.urls")),
+    path("admin/doc/", include("django.contrib.admindocs.urls")),
     # Admin Site:
-    url(r"^admin/", admin.site.urls),
+    path("admin/", admin.site.urls),
     # Robots and Favicon
-    url(
-        r"^robots\.txt$",
+    path(
+        "robots.txt",
         TemplateView.as_view(),
         {"template": "robots.txt", "mimetype": "text/plain"},
     ),
-    url(
-        r"^favicon\.ico$",
+    path(
+        "favicon.ico",
         RedirectView.as_view(permanent=True),
-        {"url": settings.STATIC_URL + "images/favicon.ico"},
+        {"path": settings.STATIC_URL + "images/favicon.ico"},
     ),
 )


### PR DESCRIPTION
Update all the urls.py to use path rather than url, update the url path and template for /terms to handle it better if no terms are defined, and to allow other slugs to be used.