### PR TITLE
Add TERMS_EXCLUDE_SUPERUSERS setting to exclude superusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,12 @@ exclude users with a custom permission you create yourself.:
 
 This can be useful if you need to run continuous login integration tests
 or simply exclude specific users from having to accept your T&Cs. Note
-that we exclude superusers from this check due to Django's has\_perm()
-method returning True for any permission check, so adding this
-permission to a superuser has no effect.
+that we exclude superusers by default from this check due to Django's
+has\_perm() method returning True for any permission check, so adding
+this permission to a superuser has no effect. If you want to exclude
+superusers you can set TERMS\_EXCLUDE\_SUPERUSERS:
+
+    TERMS_EXCLUDE_SUPERUSERS = True
 
 ### Terms and Conditions Useful Methods
 

--- a/termsandconditions/models.py
+++ b/termsandconditions/models.py
@@ -180,6 +180,10 @@ class TermsAndConditions(models.Model):
                 # Django's has_perm() returns True if is_superuser, we don't want that
                 return []
 
+        TERMS_EXCLUDE_SUPERUSERS = getattr(settings, "TERMS_EXCLUDE_SUPERUSERS", None)
+        if TERMS_EXCLUDE_SUPERUSERS and user.is_superuser:
+            return []
+
         not_agreed_terms = cache.get("tandc.not_agreed_terms_" + user.get_username())
         if not_agreed_terms is None:
             try:

--- a/termsandconditions/tests.py
+++ b/termsandconditions/tests.py
@@ -126,6 +126,12 @@ class TermsAndConditionsTests(TestCase):
         self.assertEqual(2, len(active_list))
         self.assertQuerysetEqual(active_list, [repr(self.terms3), repr(self.terms2)])
 
+    def test_superuser_excluded(self):
+        """Test su doesn't have to accept with TERMS_EXCLUDE_SUPERUSERS set"""
+        with self.settings(TERMS_EXCLUDE_SUPERUSERS=True):
+            active_list = TermsAndConditions.get_active_terms_not_agreed_to(self.su)
+            self.assertEqual([], active_list)
+
     def test_get_active_terms_ids(self):
         """Test get ids of active T&Cs"""
         active_list = TermsAndConditions.get_active_terms_ids()


### PR DESCRIPTION
Superusers are excluded from the TERMS_EXCLUDE_USERS_WITH_PERM check so they always have to accept the T&C, but I also want to exclude superusers. This change will add a TERMS_EXCLUDE_SUPERUSERS setting that will result in superusers never having to accept the T&C.