### PR TITLE
Fix open redirect vulnerability

### DIFF
--- a/termsandconditions/tests.py
+++ b/termsandconditions/tests.py
@@ -242,7 +242,7 @@ class TermsAndConditionsTests(TestCase):
         )
         self.assertContains(accept_version_post_response, "Secure")
 
-    def test_accept_redirect_safe(self):
+    def _post_accept(self, return_to):
         # Pre-accept terms 2 and 3
         UserTermsAndConditions.objects.create(user=self.user1, terms=self.terms2)
         UserTermsAndConditions.objects.create(user=self.user1, terms=self.terms3)
@@ -253,19 +253,28 @@ class TermsAndConditionsTests(TestCase):
 
         LOGGER.debug("Test /terms/accept/site-terms/1/ post")
         accept_response = self.client.post(
-            "/terms/accept/", {"terms": 1, "returnTo": "/secure/"}, follow=True
+            "/terms/accept/", {"terms": 1, "returnTo": return_to}, follow=True
         )
+        return accept_response
+
+    def test_accept_redirect_safe(self):
+        accept_response = self._post_accept("/secure/")
         self.assertRedirects(accept_response, "/secure/")
 
     def test_accept_redirect_unsafe(self):
-        # Pre-accept terms 2 and 3
-        UserTermsAndConditions.objects.create(user=self.user1, terms=self.terms2)
-        UserTermsAndConditions.objects.create(user=self.user1, terms=self.terms3)
+        accept_response = self._post_accept("http://attacker/")
+        self.assertRedirects(accept_response, "/")
 
-        LOGGER.debug("Test /terms/accept/contrib-terms/3/ post")
-        accept_response = self.client.post(
-            "/terms/accept/", {"terms": 3, "returnTo": "http://attacker/"}, follow=False
-        )
+    def test_accept_redirect_unsafe_2(self):
+        accept_response = self._post_accept("//attacker.com")
+        self.assertRedirects(accept_response, "/")
+
+    def test_accept_redirect_unsafe_3(self):
+        accept_response = self._post_accept("///attacker.com")
+        self.assertRedirects(accept_response, "/")
+
+    def test_accept_redirect_unsafe_4(self):
+        accept_response = self._post_accept("////attacker.com")
         self.assertRedirects(accept_response, "/")
 
     def test_accept_store_ip_address(self):


### PR DESCRIPTION
We've recently discovered that returnTo parameter can cause redirects outside of the application if the URL is in the form of `///attacker.com`. To prevent that, I've updated the existing check for safe URLs to use a builtin helper provided by Django which handles this (and more cases).