### PR TITLE
Update GitHub Actions versions and improve CI configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: "/"
   schedule:
     interval: daily
+    time: '12:00'
+  open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
     time: '12:00'
   open-pull-requests-limit: 10

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         django-version: [ '5.2', '6.0' ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           cache-dependency-glob: "uv.lock"
           enable-cache: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
           uv run --no-sync coverage run manage.py test
           uv run --no-sync coverage xml
       - name: codecov-umbrella
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,15 +26,17 @@ jobs:
           cache-dependency-glob: "uv.lock"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --frozen
-      - run: uv pip install "Django~=${{ matrix.django-version }}"
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Override Django version
+        run: uv pip install "Django~=${{ matrix.django-version }}"
       - name: Test
         run: |
           uv run --no-sync ruff check .
           uv run --no-sync coverage run manage.py test
           uv run --no-sync coverage xml
       - name: codecov-umbrella
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - run: uv sync
+      - run: uv sync --frozen
       - run: uv pip install "Django~=${{ matrix.django-version }}"
       - name: Test
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,14 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade uv
-        uv install setuptools wheel
+        python-version: '3.13'
     - name: Build and publish
       env:
         UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
## Summary

- Bump all GitHub Actions to latest versions
- Switch `python-publish` to use `setup-uv` (already used `uv build`/`uv publish`)
- Improve `dependabot.yml` to track action versions and use `uv` ecosystem
- Use `uv sync --frozen` in CI per setup-uv recommendations

## Details

### dependabot.yml
- Switch `pip` ecosystem to `uv` (project uses uv for dependency management)
- Add `github-actions` ecosystem so action versions are kept current automatically

### python-package.yml
- `actions/checkout` v4 → v6
- `astral-sh/setup-uv` v5 → pinned SHA (`08807647...`)
- `uv sync` → `uv sync --frozen` (fails CI if lockfile is out of date rather than silently updating it)

### python-publish.yml
- `actions/checkout` v4 → v6
- Replace `actions/setup-python` + manual `pip install uv` with `astral-sh/setup-uv` (pinned SHA)
- Remove broken `uv install setuptools wheel` step (`uv install` is not a valid command; `uv build` doesn't need them anyway)