### PR TITLE
Add Dependabot auto-merge workflow for minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+# Automatically approve and enable auto-merge on Dependabot PRs for minor/patch updates.
+# Major version bumps are left open for manual review.
+# Requires: repo "Allow auto-merge" enabled and a ruleset on main requiring the CI checks.
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve and enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that approves and enables auto-merge (squash) on Dependabot PRs for minor/patch updates. Major bumps stay open for manual review.

Repo 'Allow auto-merge' has been enabled and a ruleset on main now requires the four build checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)