### PR TITLE
Bump dependabot/fetch-metadata from 2 to 3

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve and enable auto-merge


### PR DESCRIPTION
Supersedes #525, which cannot merge as-is: its checks are stale pre-3.0 job names (`build (3.12, 5.2)`, …) while the ruleset now requires `lint` and `test (3.12, 5.2)` … `test (3.14, 6.1)`.

## Why this is safe

**`action.yml` v2 → v3 has exactly one difference:** `using: 'node20'` → `using: 'node24'`. Inputs and outputs are otherwise identical. The v3.0.0 release notes confirm the Node 24 runtime *is* the breaking change, and `ubuntu-latest` supplies it.

**`src/dependabot/output.ts` is unchanged between the tags**, so every step output keeps its name and format.

**The auto-merge condition keeps working.** `dependabot-auto-merge.yml` gates on `steps.metadata.outputs.update-type`. That value comes from this line in `update_metadata.ts`, identical in v2 and v3:

```js
const updateType = dependency['update-type'] || calculateUpdateType(lastVersion, nextVersion)
```

`dependency['update-type']` is read straight from the commit trailer, before any version inference. Every Dependabot PR in this repo carries it explicitly:

| PR | Bump | Trailer `update-type` |
|----|------|----------------------|
| #530 | `django 6.1 → 6.1.1` | `version-update:semver-patch` |
| #525 | `fetch-metadata 2 → 3` | `version-update:semver-major` |

So minor/patch still auto-merge and majors still hold for manual review, unchanged.

**Not a factor here:** v3.1.0's *"resolve update-type null for Python, Composer, and Terraform PRs"* only touches the regex fallback used when the trailer omits `update-type` — a path this repo's PRs never reach. That bug (#499, opened 2024-03) predates v3 and affects v2 equally.

`@v3` currently resolves to v3.1.0.

## Testing

- `actionlint` clean across all workflows
- `action.yml`, `src/main.ts`, `src/dependabot/output.ts` and `src/dependabot/update_metadata.ts` diffed between the v2 and v3 tags
- Real trailers from PRs #533, #530 and #525 checked against the parser's `update-type` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gqxYyaiKhrbnenR36t3gy